### PR TITLE
Update small typo in the API docs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -335,7 +335,7 @@ export interface TranslationBookChapter {
     /**
      * The link to the current chapter.
      */
-    thisChapterApiLink: string;
+    thisChapterLink: string;
 
     /**
      * The links to different audio versions for the chapter.


### PR DESCRIPTION
From `thisChapterApiLink` -> `thisChapterLink`.

I discovered this when trying to create a TS SDK for the Free Use Bible API because it was caught via schema validation. 

Hope this helps!

If the SDK works well, I'll see how I can either get it to y'all or maintain it.